### PR TITLE
Remove now-deprecated boolean argument from insert_rows

### DIFF
--- a/rpackage/src/est_param.cpp
+++ b/rpackage/src/est_param.cpp
@@ -60,7 +60,7 @@ List est_param(arma::mat xr, arma::mat xu, arma::vec kappa, arma::vec m, int n,
   if(p <= n) {
     sigma = (x.each_col() % om).t()*x;
     arma::vec happend = h;
-    happend.insert_rows(0, nvars - r, true);
+    happend.insert_rows(0, nvars - r);
     sigma.diag() += happend;
     if(elbo) {
       ldetsig = - real(log_det(sigma));


### PR DESCRIPTION
When updating RcppArmadillo to no longer suppress deprecation warning, initially for the value setting use described and changed in detail in https://github.com/RcppCore/RcppArmadillo/issues/391, we found one statement in your package also triggering a warning 

    Found the following significant warnings:
      est_param.cpp:61:24: warning: ‘void arma::Col<eT>::insert_rows(arma::uword, arma::uword, bool) 
         [with eT = double; arma::uword = unsigned int]’ is deprecated [-Wdeprecated-declarations]

The fix is very simple:  we can simple remove the trailing `true` as Armadillo now defaults to setting zero values in added rows.

It would be much appreciated if you could apply this simple pull request and update the package at CRAN within the next few months.   Let me know if you have any questions.